### PR TITLE
Update README descriptions to Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains a collection of Python scripts that demonstrate how to 
 
 Check the `samples` directory for the available scripts.
 
-* [chat_error_contentfilter.py](samples/chat_error_contentfilter.py): Makes a chat completion call with OpenAI package with a violent message and handles the content safety error in the response.
-* [chat_error_jailbreak.py](samples/chat_error_jailbreak.py): Makes a chat completion call with OpenAI package with a jailbreak attempt and handles the content safety error in the response.
+* [chat_error_contentfilter.py](samples/chat_error_contentfilter.py): Makes a Responses API call with the OpenAI package using a violent message and handles the content safety error in the response.
+* [chat_error_jailbreak.py](samples/chat_error_jailbreak.py): Makes a Responses API call with the OpenAI package using a jailbreak attempt and handles the content safety error in the response.
 * [quality_eval_groundedness.py](samples/quality_eval_groundedness.py): Evaluates the groundedness of a sample answer and sources using the Azure AI Evaluation SDK.
 * [quality_eval_all_builtin_judges.py](samples/quality_eval_all_builtin_judges.py): Evaluates the quality of a sample query and answer using all of the built-in GPT-based evaluators in the Azure AI Evaluation SDK.
 * [quality_eval_custom.py](samples/quality_eval_custom.py): Evaluates the quality of a sample query and answer with the Azure AI Evaluation SDK using a custom evaluator for "friendliness".

--- a/samples/spanish/README.md
+++ b/samples/spanish/README.md
@@ -6,8 +6,8 @@ Este repositorio contiene una colección de scripts de Python que muestran cómo
 
 Revisa el directorio `samples/spanish` para ver los scripts disponibles.
 
-* [chat_error_contentfilter.py](samples/spanish/chat_error_contentfilter.py): Hace una llamada de chat completion con el paquete de OpenAI con un mensaje violento y maneja el error de seguridad de contenido en la respuesta.
-* [chat_error_jailbreak.py](samples/spanish/chat_error_jailbreak.py): Hace una llamada de chat completion con el paquete de OpenAI con un intento de jailbreak y maneja el error de seguridad de contenido en la respuesta.
+* [chat_error_contentfilter.py](samples/spanish/chat_error_contentfilter.py): Hace una llamada a la Responses API con el paquete de OpenAI usando un mensaje violento y maneja el error de seguridad de contenido en la respuesta.
+* [chat_error_jailbreak.py](samples/spanish/chat_error_jailbreak.py): Hace una llamada a la Responses API con el paquete de OpenAI usando un intento de jailbreak y maneja el error de seguridad de contenido en la respuesta.
 * [quality_eval_groundedness.py](samples/spanish/quality_eval_groundedness.py): Evalúa la fundamentación de una respuesta de muestra y fuentes usando el Azure AI Evaluation SDK.
 * [quality_eval_all_builtin_judges.py](samples/spanish/quality_eval_all_builtin_judges.py): Evalúa la calidad de una consulta y respuesta de muestra usando todos los evaluadores basados en GPT integrados en el Azure AI Evaluation SDK.
 * [quality_eval_custom.py](samples/spanish/quality_eval_custom.py): Evalúa la calidad de una consulta y respuesta de muestra con el Azure AI Evaluation SDK usando un evaluador personalizado para "amabilidad".


### PR DESCRIPTION
## Summary
Update the English and Spanish READMEs so the sample descriptions match the current API usage.

## What changed
- replace the outdated `chat completion` wording for the content filter and jailbreak samples
- describe both samples as using the Responses API
- apply the same wording fix in the Spanish README

## Why
The sample scripts use `client.responses.create(...)`, so the README descriptions should reflect the Responses API rather than chat completions.