### PR TITLE
Pass principalType into Foundry AI module role assignments

### DIFF
--- a/infra/core/ai/foundry.bicep
+++ b/infra/core/ai/foundry.bicep
@@ -98,7 +98,7 @@ resource projectRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '53ca6127-db72-4b80-b1b0-d745d6d5456d') // Azure AI User
     principalId: principalId
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -109,7 +109,7 @@ resource accountRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '53ca6127-db72-4b80-b1b0-d745d6d5456d') // Azure AI User
     principalId: principalId
-    principalType: 'User'
+    principalType: principalType
   }
 }
 

--- a/infra/core/ai/foundry.bicep
+++ b/infra/core/ai/foundry.bicep
@@ -91,7 +91,7 @@ resource storageRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
   }
 }
 
-// Assign a role to the calling user for the AI Foundry project (needed for projects (including agents) API)
+// Assign a role to the principal for the AI Foundry project (needed for projects (including agents) API)
 resource projectRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(project.id, 'Azure AI User', principalId)
   scope: project
@@ -102,7 +102,7 @@ resource projectRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
   }
 }
 
-// Assign a role to the calling user for the AI Foundry account (needed for Azure OpenAI API)
+// Assign a role to the principal for the AI Foundry account (needed for Azure OpenAI API)
 resource accountRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(account.id, 'Azure AI User', principalId)
   scope: account


### PR DESCRIPTION
## Summary
- Use the existing module parameter principalType for AI User role assignments in the Foundry module
- Replace hardcoded User principal type on project/account role assignments

## Why
GitHub Actions deployments use a service principal, so hardcoding User causes incorrect role assignment behavior in pipeline scenarios.

## Validation
- az bicep build --file infra/main.bicep